### PR TITLE
Add basic CSS and link from default layout

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,9 +5,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ page.title | default: site.title }}</title>
-    <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
+    <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
   </head>
-  <body>
+  <body class="container">
     <section class="page-header">
       <h1 class="project-name">{{ site.title | default: page.title }}</h1>
       {% if site.description %}

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,36 @@
+/* Base typography */
+body {
+  font-family: Arial, Helvetica, sans-serif;
+  color: #333;
+  line-height: 1.6;
+  background-color: #f8f8f8;
+  margin: 0;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  color: #222;
+  margin-top: 0;
+}
+
+a {
+  color: #0069d9;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+/* Responsive container */
+.container {
+  width: 90%;
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 15px;
+}
+
+@media (min-width: 768px) {
+  .container {
+    width: 80%;
+  }
+}


### PR DESCRIPTION
## Summary
- provide baseline CSS for layout and typography
- link new stylesheet in the default layout and wrap body in responsive container

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fa636f4dc8331bd3327b1ccc54305