### PR TITLE
Add nav toggle focus style

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -47,6 +47,11 @@ a:hover {
   border: none;
   cursor: pointer;
 }
+.nav-toggle:focus {
+  outline: 2px solid #0069d9;
+  outline-offset: 2px;
+}
+
 .nav-menu {
   list-style: none;
   margin: 0;


### PR DESCRIPTION
## Summary
- add a focus outline for the mobile nav toggle button so keyboard users can see when it is focused

## Testing
- `bundle exec jekyll build` *(fails: bundler/jekyll not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685faa8e7fb88331971c0580311a130b