### PR TITLE
Remove Jekyll theme

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,2 @@
-theme: jekyll-theme-cayman
 title: Waliduino Guide
 description: Learn electronics and programming with the Waliduino board.

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,4 +1,4 @@
-/* Base typography */
+/* Custom Waliduino styles - overrides any default theme */
 body {
   font-family: Arial, Helvetica, sans-serif;
   color: #333;


### PR DESCRIPTION
## Summary
- drop the default `jekyll-theme-cayman` entry
- note in `style.css` that it overrides any default theme

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fac2644fc8331b63b77a361dbf875