### PR TITLE
Fix hero banner layout

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -101,6 +101,11 @@ a:hover {
   text-align: center;
   color: #fff;
   margin-bottom: 2rem;
+  background-color: #0069d9;
+  min-height: 200px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 .hero-banner img {
   width: 100%;
@@ -108,11 +113,9 @@ a:hover {
   display: block;
 }
 .hero-headline {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  background: rgba(0, 0, 0, 0.5);
-  padding: 1rem 2rem;
-  border-radius: 4px;
+  position: static;
+  transform: none;
+  background: none;
+  padding: 0;
+  margin: 0;
 }


### PR DESCRIPTION
## Summary
- fix hero banner styling to prevent overlapping text after hero image removal

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685fcbcec57883318336bc7c9e03f92e