### PR TITLE
Fix nav rail overlay

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -46,6 +46,7 @@ a:hover {
   color: #fff;
   padding-top: 2rem;
   box-sizing: border-box;
+  z-index: 999;
 }
 .nav-rail a {
   color: #fff;


### PR DESCRIPTION
## Summary
- ensure the sidebar navigation sits above the hero banner by adding a z-index

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685fd6060a048331889a500244e008c8